### PR TITLE
Changes http.get to http.requests

### DIFF
--- a/nodejs/chat.js
+++ b/nodejs/chat.js
@@ -48,7 +48,7 @@ io.sockets.on('connection', function (socket) {
         };
         
         //Send message to Django server
-        var req = http.get(options, function(res){
+        var req = http.request(options, function(res){
             res.setEncoding('utf8');
             
             //Print out error message


### PR DESCRIPTION
Django server expects a post request, but chat.js is using http.get which kinds of ignore the request options.
